### PR TITLE
Use findtext to handle self-terminating description tags

### DIFF
--- a/ammo/fomod_controller.py
+++ b/ammo/fomod_controller.py
@@ -138,9 +138,7 @@ class FomodController(Controller):
                         plug_dict = {}
                         plugin_name = plugin.get("name").strip()
                         plug_dict["name"] = plugin_name
-                        plug_dict["description"] = ""
-                        if (description := plugin.find("description")) is not None:
-                            plug_dict["description"] = description.text.strip()
+                        plug_dict["description"] = plugin.findtext("description",default="").strip()
                         plug_dict["flags"] = {}
                         # Automatically mark the first option as selected when
                         # a selection is required.


### PR DESCRIPTION
Should fix #38 
This let me run through the installer fine, and I believe it'll mimic the current behavior of "" for no text, no description tag, or an empty description tag. I haven't actually tested my game with the new mods, but that's probably beyond our scope here. 