### PR TITLE
Add remote pipx install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ git clone https://github.com/cyberrumor/ammo
 cd ammo
 pipx install . --force
 ```
+or if you don't want to contribute, just run
+
+```
+pipx install git+https://github.com/cyberrumor/ammo
+```
 
 ## Usage
 


### PR DESCRIPTION
Cloning the repo is not mandatory to use pipx, especially if you don't care about contributing